### PR TITLE
Fix build against Xen 4.7

### DIFF
--- a/lib/gntshr_stubs.c
+++ b/lib/gntshr_stubs.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <assert.h>
 
+#define XC_WANT_COMPAT_GNTTAB_API
 #include <xenctrl.h>
 
 #if __XEN_INTERFACE_VERSION__ >= 0x00040200

--- a/lib/gnttab_stubs.c
+++ b/lib/gnttab_stubs.c
@@ -30,6 +30,7 @@
 #include <caml/callback.h>
 #include <caml/bigarray.h>
 
+#define XC_WANT_COMPAT_GNTTAB_API
 #include <xenctrl.h>
 
 #define _G(__g) ((xc_gnttab *)(__g))


### PR DESCRIPTION
Upstream Xen has split several pieces of functionality out of libxc
http://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=a71ad0feada081b80beb85702e8039bcbc847b73
in an effort to make a stable library for future use.

Ask for the compatibility API when compiling.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>