### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/xen-gnt-unix.opam
+++ b/xen-gnt-unix.opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/ocaml-gnt/"
 bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "xen-gnt"
   "io-page-unix" {>= "2.0.0"}
 ]

--- a/xen-gnt.opam
+++ b/xen-gnt.opam
@@ -12,7 +12,7 @@ doc: "https://mirage.github.io/ocaml-gnt/"
 bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "1.0.1"}
   "io-page"
   "lwt" {>= "2.4.3"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.