### PR TITLE
fix warnings in gntshr_stubs

### DIFF
--- a/lib/gntshr_stubs.c
+++ b/lib/gntshr_stubs.c
@@ -44,7 +44,7 @@ CAMLprim value stub_gntshr_allocates(void)
 
 static void gntshr_missing()
 {
-	value *v = caml_named_value("gntshr.missing");
+	const value *v = caml_named_value("gntshr.missing");
 	/* if v is NULL then it's either an error in gntshr.ml or a
 	   linking error */ 
 	assert (v != NULL);
@@ -54,27 +54,6 @@ static void gntshr_missing()
 #define _G(__g) ((xc_gntshr *)(__g))
 
 #define XC_GNTTAB_BIGARRAY (CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL)
-
-#ifdef HAVE_GNTSHR
-#define ERROR_STRLEN 1030
-static void failwith_xc(xc_interface *xch)
-{
-        static char error_str[ERROR_STRLEN];
-        if (xch) {
-                const xc_error *error = xc_get_last_error(xch);
-                if (error->code == XC_ERROR_NONE)
-                        snprintf(error_str, ERROR_STRLEN, "%d: %s", errno, strerror(errno));
-                else
-                        snprintf(error_str, ERROR_STRLEN, "%d: %s: %s",
-                                 error->code,
-                                 xc_error_code_to_desc(error->code),
-                                 error->message);
-        } else {
-                snprintf(error_str, ERROR_STRLEN, "Unable to open XC interface");
-        }
-        caml_failwith(error_str);
-}
-#endif
 
 CAMLprim value stub_gntshr_open(value unit)
 {
@@ -130,7 +109,7 @@ CAMLprim value stub_gntshr_share_pages_batched(value xgh, value domid, value cou
 
 	if(NULL == map) {
 		free(refs);
-		failwith_xc(_G(xgh));
+		caml_failwith("Failed to share pages");
 	}
 
 	// Construct the list of grant references.
@@ -144,7 +123,7 @@ CAMLprim value stub_gntshr_share_pages_batched(value xgh, value domid, value cou
 		ml_refs = ml_refs_cons;
 	}
 
-	ml_map = alloc_bigarray_dims(XC_GNTTAB_BIGARRAY, 1,
+	ml_map = caml_ba_alloc_dims(XC_GNTTAB_BIGARRAY, 1,
                               map, (c_count << XC_PAGE_SHIFT));
 
 	Store_field(result, 0, ml_refs);
@@ -163,17 +142,17 @@ CAMLprim value stub_gntshr_munmap_batched(value xgh, value share) {
 #ifdef HAVE_GNTSHR
 	ml_map = Field(share, 1);
 
-	int size = Bigarray_val(ml_map)->dim[0];
+	int size = Caml_ba_array_val(ml_map)->dim[0];
 	int pages = size >> XC_PAGE_SHIFT;
 #ifdef linux
 	/* Bug in xen-4.4 libxc xc_linux_osdep implementation, work-around
 	   by using the kernel interface directly. */
-	int result = munmap(Data_bigarray_val(ml_map), size);
+	int result = munmap(Caml_ba_data_val(ml_map), size);
 #else
-	int result = xc_gntshr_munmap(_G(xgh), Data_bigarray_val(ml_map), pages);
+	int result = xc_gntshr_munmap(_G(xgh), Caml_ba_data_val(ml_map), pages);
 #endif
 	if(result != 0)
-		failwith_xc(_G(xgh));
+		caml_failwith("Failed to munmap pages");
 #else
 	gntshr_missing();
 #endif


### PR DESCRIPTION
Hello devs,
This PR should fix #48 . I was unsure how `failwith_xc(_G(xgh));` should work as it provides a `xc_gntshr *` (aka. `struct xengntdev_handle*`) which is really different from the expected `xc_interface*` (aka. `struct xc_interface_core*`). So now I fail with `caml_failwith(_)` to keep the failing behavior and the string is constant (we lose the errno code information).
Best.